### PR TITLE
commitlint fix

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx commitlint --edit 
+npx commitlint --edit "$1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "declarations.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "husky install"
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. using pre-commit solely was a mistake: replaced with correct commit-msg hook
2. husky install needed to be put inside the script prepare instead of postinstall, which is used for yarn
3. script inside commit-msg now includes the reference to the message which is passed to the script via "$1"