### PR TITLE
Feat/add bootstrap

### DIFF
--- a/registri.css
+++ b/registri.css
@@ -78,6 +78,8 @@ header {
   display: flex;
   justify-content: space-between;
   margin: 20px;
+
+  min-height: 400px;
 }
 
 .ListaRegistri {

--- a/registri.css
+++ b/registri.css
@@ -12,8 +12,7 @@
   padding: 0;
 }
 
-
-:root{
+:root {
   /* body palette */
   --header-black: #000;
   --header-white: #fff;
@@ -36,11 +35,8 @@
   --team-color-7: #001938;
 }
 
-
-
 /* Default style for body */
 body {
-
   font-family: 'Istok Web', sans-serif;
   background-color: var(--header-white);
   /*
@@ -50,7 +46,14 @@ body {
   line-height: normal; */
 }
 
-h1, h2, h3, h4, h5, h6, p, ul {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+ul {
   margin: 0;
   padding: 0;
 }

--- a/registri.css
+++ b/registri.css
@@ -44,6 +44,15 @@ body {
   font-style: normal;
   font-weight: 700;
   line-height: normal; */
+
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.FlexedToGrow {
+  flex-grow: 1;
+  background-color: white;
 }
 
 h1,
@@ -79,7 +88,7 @@ header {
   justify-content: space-between;
   margin: 20px;
 
-  min-height: 400px;
+  /* min-height: 400px; */
 }
 
 /* .ListaRegistri {

--- a/registri.css
+++ b/registri.css
@@ -82,9 +82,9 @@ header {
   min-height: 400px;
 }
 
-.ListaRegistri {
+/* .ListaRegistri {
   width: 20%;
-}
+} */
 
 .TuttiIRegistri {
   font-size: 18px;
@@ -109,9 +109,9 @@ header {
   cursor: pointer;
 }
 
-.VisualeLezione {
+/* .VisualeLezione {
   width: 60%;
-}
+} */
 
 .TitoloMateria {
   font-size: 24px;
@@ -132,9 +132,9 @@ header {
   cursor: pointer;
 }
 
-.MenuEdita {
+/* .MenuEdita {
   width: 15%;
-}
+} */
 
 .Edita {
   font-size: 18px;

--- a/registri.css
+++ b/registri.css
@@ -95,6 +95,12 @@ header {
   width: 20%;
 } */
 
+.ListaRegistri,
+.MenuEdita {
+  background-color: var(--primary-color);
+  padding: 10px;
+}
+
 .TuttiIRegistri {
   font-size: 18px;
 }
@@ -102,6 +108,9 @@ header {
 .Lista {
   list-style-type: none;
   margin-top: 10px;
+
+  background-color: var(--header-white);
+  padding: 13px;
 }
 
 .Materia {
@@ -118,9 +127,12 @@ header {
   cursor: pointer;
 }
 
-/* .VisualeLezione {
-  width: 60%;
-} */
+.VisualeLezione {
+  /* width: 60%; */
+
+  background-color: var(--secondary-color);
+  padding: 20px;
+}
 
 .TitoloMateria {
   font-size: 24px;

--- a/registri.css
+++ b/registri.css
@@ -37,7 +37,7 @@
 
 /* Default style for body */
 body {
-  font-family: 'Istok Web', sans-serif;
+  font-family: 'Istok Web', sans-serif !important;
   background-color: var(--header-white);
   /*
   font-size: 51px;

--- a/registri.html
+++ b/registri.html
@@ -24,17 +24,13 @@
     ></script>
   </head>
   <body>
-    <div class="container-fluid">
-      <div class="row">
-        <div class="col">
-          <header>
-            <nav class="Nav">
-              <h1 class="PortaleScuola">Portale Scuola</h1>
-            </nav>
-          </header>
-        </div>
-      </div>
+    <header>
+      <nav class="Nav navbar">
+        <h1 class="PortaleScuola">Portale Scuola</h1>
+      </nav>
+    </header>
 
+    <div class="container-fluid">
       <div class="row">
         <div class="col">
           <main class="Main">

--- a/registri.html
+++ b/registri.html
@@ -30,16 +30,16 @@
       </nav>
     </header>
 
-    <div class="container-fluid FlexedToGrow">
-      <div class="row">
-        <div class="col">
-          <main class="Main">
-            <div class="container-fluid container-xs">
-              <div class="row">
-                <div class="col-md-3">
-                  <aside class="ListaRegistri">
+    <div class="container-fluid d-flex flex-grow-1">
+      <div class="row d-flex flex-row flex-grow-1">
+        <div class="col d-flex">
+          <main class="Main d-flex flex-grow-1">
+            <div class="container-fluid container-xs d-flex">
+              <div class="row d-flex flex-row flex-grow-1">
+                <div class="col-md-3 d-flex flex-grow-1">
+                  <aside class="ListaRegistri d-flex flex-column flex-grow-1">
                     <h3 class="TuttiIRegistri">Tutti i registri</h3>
-                    <ul class="Lista">
+                    <ul class="Lista flex-grow-1">
                       <li class="Materia">
                         <button class="TitoloMateria">
                           <h4 class="Chimica">Chimica</h4>

--- a/registri.html
+++ b/registri.html
@@ -15,6 +15,12 @@
       integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
       crossorigin="anonymous"
     />
+
+    <!-- scripts -->
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
+      crossorigin="anonymous"
     ></script>
   </head>
   <body>

--- a/registri.html
+++ b/registri.html
@@ -8,7 +8,14 @@
     <title>Portale Scuola</title>
 
     <!-- stylesheets -->
-    <link rel="stylesheet" href="registri.css">
+    <link rel="stylesheet" href="registri.css" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
+      crossorigin="anonymous"
+    />
+    ></script>
   </head>
   <body>
     <header>

--- a/registri.html
+++ b/registri.html
@@ -80,8 +80,7 @@
 
       <div class="row">
         <div class="col">
-          <!-- TODO : change this into semantic tag, maybe -->
-          <div class="Footer"></div>
+          <footer class="Footer"></footer>
         </div>
       </div>
     </div>

--- a/registri.html
+++ b/registri.html
@@ -75,9 +75,7 @@
       </div>
 
       <div class="row">
-        <div class="col">
-          <footer class="Footer"></footer>
-        </div>
+        <footer class="Footer"></footer>
       </div>
     </div>
   </body>

--- a/registri.html
+++ b/registri.html
@@ -34,42 +34,54 @@
       <div class="row">
         <div class="col">
           <main class="Main">
-            <aside class="ListaRegistri">
-              <h3 class="TuttiIRegistri">Tutti i registri</h3>
-              <ul class="Lista">
-                <li class="Materia">
-                  <button class="TitoloMateria">
-                    <h4 class="Chimica">Chimica</h4>
-                  </button>
-                </li>
-                <li class="Materia">
-                  <button class="TitoloMateria">
-                    <h4 class="aggiungi">+</h4>
-                  </button>
-                </li>
-              </ul>
-            </aside>
-            <section class="VisualeLezione">
-              <h2 class="TitoloMateria">Chimica</h2>
-              <div class="OpzioniMateria">
-                <button class="BottoneElencaStudenti">
-                  <a href="elenco.html">Elenco studenti</a>
-                </button>
+            <div class="container">
+              <div class="row">
+                <div class="col-md-3">
+                  <aside class="ListaRegistri">
+                    <h3 class="TuttiIRegistri">Tutti i registri</h3>
+                    <ul class="Lista">
+                      <li class="Materia">
+                        <button class="TitoloMateria">
+                          <h4 class="Chimica">Chimica</h4>
+                        </button>
+                      </li>
+                      <li class="Materia">
+                        <button class="TitoloMateria">
+                          <h4 class="aggiungi">+</h4>
+                        </button>
+                      </li>
+                    </ul>
+                  </aside>
+                </div>
 
-                <button class="BottoneMostraLezioni">
-                  <a class="Lezioni">Lezioni</a>
-                </button>
+                <div class="col-md-7">
+                  <section class="VisualeLezione">
+                    <h2 class="TitoloMateria">Chimica</h2>
+                    <div class="OpzioniMateria">
+                      <button class="BottoneElencaStudenti">
+                        <a href="elenco.html">Elenco studenti</a>
+                      </button>
+
+                      <button class="BottoneMostraLezioni">
+                        <a class="Lezioni">Lezioni</a>
+                      </button>
+                    </div>
+                  </section>
+                </div>
+
+                <div class="col-md-2">
+                  <aside class="MenuEdita">
+                    <h3 class="Edita">edita</h3>
+
+                    <ul class="Lista">
+                      <li class="Opzione">
+                        <button class="EliminaRegistro">elimina registro</button>
+                      </li>
+                    </ul>
+                  </aside>
+                </div>
               </div>
-            </section>
-            <aside class="MenuEdita">
-              <h3 class="Edita">edita</h3>
-
-              <ul class="Lista">
-                <li class="Opzione">
-                  <button class="EliminaRegistro">elimina registro</button>
-                </li>
-              </ul>
-            </aside>
+            </div>
           </main>
         </div>
       </div>

--- a/registri.html
+++ b/registri.html
@@ -34,7 +34,7 @@
       <div class="row">
         <div class="col">
           <main class="Main">
-            <div class="container">
+            <div class="container-fluid container-xs">
               <div class="row">
                 <div class="col-md-3">
                   <aside class="ListaRegistri">

--- a/registri.html
+++ b/registri.html
@@ -8,13 +8,13 @@
     <title>Portale Scuola</title>
 
     <!-- stylesheets -->
-    <link rel="stylesheet" href="registri.css" />
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
       rel="stylesheet"
       integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
       crossorigin="anonymous"
     />
+    <link rel="stylesheet" href="registri.css" />
 
     <!-- scripts -->
     <script

--- a/registri.html
+++ b/registri.html
@@ -87,8 +87,10 @@
       </div>
     </div>
 
-    <div class="row">
-      <footer class="Footer"></footer>
+    <div class="container-fluid">
+      <div class="row">
+        <footer class="Footer"></footer>
+      </div>
     </div>
   </body>
 </html>

--- a/registri.html
+++ b/registri.html
@@ -30,7 +30,7 @@
       </nav>
     </header>
 
-    <div class="container-fluid">
+    <div class="container-fluid FlexedToGrow">
       <div class="row">
         <div class="col">
           <main class="Main">
@@ -85,10 +85,10 @@
           </main>
         </div>
       </div>
+    </div>
 
-      <div class="row">
-        <footer class="Footer"></footer>
-      </div>
+    <div class="row">
+      <footer class="Footer"></footer>
     </div>
   </body>
 </html>

--- a/registri.html
+++ b/registri.html
@@ -24,50 +24,66 @@
     ></script>
   </head>
   <body>
-    <header>
-      <nav class="Nav">
-        <h1 class="PortaleScuola">Portale Scuola</h1>
-      </nav>
-    </header>
-
-    <main class="Main">
-      <aside class="ListaRegistri">
-        <h3 class="TuttiIRegistri">Tutti i registri</h3>
-        <ul class="Lista">
-          <li class="Materia">
-            <button class="TitoloMateria">
-              <h4 class="Chimica">Chimica</h4>
-            </button>
-          </li>
-          <li class="Materia">
-            <button class="TitoloMateria">
-              <h4 class="aggiungi">+</h4>
-            </button>
-          </li>
-        </ul>
-      </aside>
-      <section class="VisualeLezione">
-        <h2 class="TitoloMateria">Chimica</h2>
-        <div class="OpzioniMateria">
-          <button class="BottoneElencaStudenti">
-            <a href="elenco.html">Elenco studenti</a>
-          </button>
-
-          <button class="BottoneMostraLezioni">
-            <a class="Lezioni">Lezioni</a>
-          </button>
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col">
+          <header>
+            <nav class="Nav">
+              <h1 class="PortaleScuola">Portale Scuola</h1>
+            </nav>
+          </header>
         </div>
-      </section>
-      <aside class="MenuEdita">
-        <h3 class="Edita">edita</h3>
+      </div>
 
-        <ul class="Lista">
-          <li class="Opzione">
-            <button class="EliminaRegistro">elimina registro</button>
-          </li>
-        </ul>
-      </aside>
-    </main>
-    <div class="Footer"></div>
+      <div class="row">
+        <div class="col">
+          <main class="Main">
+            <aside class="ListaRegistri">
+              <h3 class="TuttiIRegistri">Tutti i registri</h3>
+              <ul class="Lista">
+                <li class="Materia">
+                  <button class="TitoloMateria">
+                    <h4 class="Chimica">Chimica</h4>
+                  </button>
+                </li>
+                <li class="Materia">
+                  <button class="TitoloMateria">
+                    <h4 class="aggiungi">+</h4>
+                  </button>
+                </li>
+              </ul>
+            </aside>
+            <section class="VisualeLezione">
+              <h2 class="TitoloMateria">Chimica</h2>
+              <div class="OpzioniMateria">
+                <button class="BottoneElencaStudenti">
+                  <a href="elenco.html">Elenco studenti</a>
+                </button>
+
+                <button class="BottoneMostraLezioni">
+                  <a class="Lezioni">Lezioni</a>
+                </button>
+              </div>
+            </section>
+            <aside class="MenuEdita">
+              <h3 class="Edita">edita</h3>
+
+              <ul class="Lista">
+                <li class="Opzione">
+                  <button class="EliminaRegistro">elimina registro</button>
+                </li>
+              </ul>
+            </aside>
+          </main>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col">
+          <!-- TODO : change this into semantic tag, maybe -->
+          <div class="Footer"></div>
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/registri.html
+++ b/registri.html
@@ -54,8 +54,8 @@
                   </aside>
                 </div>
 
-                <div class="col-md-7">
-                  <section class="VisualeLezione">
+                <div class="col-md-7 d-flex flex-column flex-grow-1">
+                  <section class="VisualeLezione d-flex flex-column flex-grow-1">
                     <h2 class="TitoloMateria">Chimica</h2>
                     <div class="OpzioniMateria">
                       <button class="BottoneElencaStudenti">
@@ -66,14 +66,16 @@
                         <a class="Lezioni">Lezioni</a>
                       </button>
                     </div>
+
+                    <div class="Registro flex-grow-1"></div>
                   </section>
                 </div>
 
-                <div class="col-md-2">
-                  <aside class="MenuEdita">
+                <div class="col-md-2 d-flex flex-column flex-grow-1">
+                  <aside class="MenuEdita d-flex flex-column flex-grow-1">
                     <h3 class="Edita">edita</h3>
 
-                    <ul class="Lista">
+                    <ul class="Lista flex-grow-1">
                       <li class="Opzione">
                         <button class="EliminaRegistro">elimina registro</button>
                       </li>


### PR DESCRIPTION
Now Bootstraps allow us to have : 
- `.ListaRegistri` with col 3 for Medium screens or more
- `.VisualeLezione` with col 7 for Medium screens or more
- `.MenuEdita` with col 2 for Medium screens or more

Fix: elements between `header` and `footer` now take full space with `flex-grow: 1`

BUG: flex somehow activate overflow with both vertical and horizontal scrollbar