### PR TITLE
JS imports declaration

### DIFF
--- a/registri.html
+++ b/registri.html
@@ -24,7 +24,7 @@
       crossorigin="anonymous"
     ></script>
     <script src="script.js"></script>
-    <script src="view.js" defer></script>
+    <script type="module" src="view.js" defer></script>
   </head>
   <body>
     <header>

--- a/script.js
+++ b/script.js
@@ -224,3 +224,5 @@ const getStudent = (id) => {
 //   getRegister,
 //   getStudent
 // };
+
+export { registers };

--- a/view.js
+++ b/view.js
@@ -1,4 +1,5 @@
 // File per modificare il Prensentation Layer (aka aggire sull' HTML modificando il DOM)
+import { registers } from "./script.js";
 
 const notImplemented = () => {
   alert("Not Implemented Yet");


### PR DESCRIPTION
Previously there was a module.import which now could work since we added node, but now imports are declared as [JS modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).

For now, only the list of register is imported. But the scope of this commit is to insert the structure of the imports. Later imports can be added as needed.