### PR TITLE
fix(js): bugs of buttons in main

### DIFF
--- a/registri.html
+++ b/registri.html
@@ -59,15 +59,11 @@
 
                 <div class="col-md-7 d-flex flex-column flex-grow-1">
                   <section class="VisualeLezione d-flex flex-column flex-grow-1">
-                    <h2 class="TitoloMateria">Chimica</h2>
+                    <h2 class="">Chimica</h2>
                     <div class="OpzioniMateria">
-                      <button class="btn btn-primary BottoneElencaStudenti">
-                        Elenco studenti
-                      </button>
+                      <button class="btn btn-primary BottoneElencaStudenti" id="ElencoStudenti">Elenco studenti</button>
 
-                      <button class="btn btn-primary BottoneMostraLezioni">
-                        Lezioni
-                      </button>
+                      <button class="btn btn-primary BottoneMostraLezioni">Lezioni</button>
                     </div>
 
                     <div class="Registro flex-grow-1"></div>

--- a/view.js
+++ b/view.js
@@ -7,7 +7,7 @@ const notImplemented = () => {
 
 // inserire le manipolazioni del dom qui dentro
 document.addEventListener('DOMContentLoaded', function () {
-  var goToStudentsList = document.querySelector('.ElencoStudenti');
+  var goToStudentsList = document.querySelector('#ElencoStudenti');
   var goToLectures = document.querySelector('.BottoneMostraLezioni');
   var deleteRegister = document.querySelector('.EliminaRegistro');
 
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // NOTE : questo funzionava solo sul testo, ora sul div arrotondato. MAYBE deve essere rifinito
   if (goToStudentsList) {
-    goToStudentsList.parentNode.parentNode.addEventListener('click', notImplemented);
+    goToStudentsList.addEventListener('click', notImplemented);
   }
 
   if (goToLectures) {


### PR DESCRIPTION
The Heading in the central column should not be a button/not call `notImplemented()`, so I removed the class `.TitoloMateria` from HTML inside that

The button Elenco Studenti never calls `notImplemented()` because it didn't have a class `.ElencoStudenti` to begin with... So to fix that gave that elem an id `#ElencoStudenti`, and got that with querySelector
Then removed the parentNode workaround for that element